### PR TITLE
Restore VOMS deployment test

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     ports:
       - "8443:8443"
       - "15000:15000"
+      - "15001:15001"
 
     privileged: true
 

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.7'
 
 volumes:
   sync:
@@ -6,6 +6,7 @@ volumes:
 services:
   testsuite:
     image: italiangrid/voms-testsuite-centos7
+    init: true
 
     environment:
       VOMS_HOSTNAME: dev.local.io
@@ -14,6 +15,8 @@ services:
 
     volumes:
       - sync:/sync
+    
+    command: ["sleep", "infinity"]
 
   voms:
     image: italiangrid/voms-deployment-test-centos7

--- a/docker/all-in-one-centos7/Dockerfile
+++ b/docker/all-in-one-centos7/Dockerfile
@@ -3,34 +3,28 @@ FROM centos:7
 # Allow customization of test user ID and name
 ARG TEST_USER=test
 ARG TEST_USER_UID=501
+
 ARG UMD_RELEASE_PACKAGE_URL=http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm
 
-# Enable systemd
-ENV container docker
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
-systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
-rm -f /etc/systemd/system/*.wants/*;\
-rm -f /lib/systemd/system/local-fs.target.wants/*; \
-rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*;
+RUN echo "include_only=.garr.it,.cern.ch" >> /etc/yum/pluginconf.d/fastestmirror.conf && \
+  yum -y install hostname which wget tar sudo file less epel-release ${UMD_RELEASE_PACKAGE_URL} && \
+  yum -y update && \
+  yum clean all && \
+  rm -rf /var/cache/yum && \
+  adduser --uid ${TEST_USER_UID} ${TEST_USER} && \
+  echo ${TEST_USER} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${TEST_USER} && \
+  chmod 0440 /etc/sudoers.d/${TEST_USER} && \
+  (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do \
+  [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+  rm -f /lib/systemd/system/multi-user.target.wants/*; \
+  rm -f /etc/systemd/system/*.wants/*; \
+  rm -f /lib/systemd/system/local-fs.target.wants/*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+  rm -f /lib/systemd/system/basic.target.wants/*; \
+  rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+ENV container=docker
 
 VOLUME [ "/sys/fs/cgroup" ]
 CMD ["/usr/sbin/init"]
-
-RUN echo "include_only=.garr.it,.cern.ch" >> /etc/yum/pluginconf.d/fastestmirror.conf && \
-  yum clean all && \
-  yum install -y hostname epel-release && \
-  yum -y update && \
-  yum -y install which wget tar sudo file && \
-  yum -y install which wget tar sudo file && \
-  echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-  adduser --uid ${TEST_USER_UID} ${TEST_USER} && \
-  usermod -a -G wheel ${TEST_USER} 
-
-RUN yum -y install ${UMD_RELEASE_PACKAGE_URL} && \
-  yum -y update && \
-  yum clean all && \
-  rm -rf /var/cache/yum


### PR DESCRIPTION
Fix integration of systemd in Dockerfile: do container-specific changes to systemd services and targets after `yum update`, because changes would be undone by an update of systemd.

Other changes:

* create a user-specific file under sudoers.d instead of touching the
  main sudoers file
* review installed packages

See https://issues.infn.it/jira/browse/VOMS-882